### PR TITLE
fix: check for topics which don't match the schema

### DIFF
--- a/mqtt.go
+++ b/mqtt.go
@@ -5,11 +5,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 	"strings"
 	"time"
-
-	"log"
 
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
@@ -135,6 +134,10 @@ func mqttSubscriptionHandler(client mqtt.Client, msg mqtt.Message) {
 
 	topic := msg.Topic()
 	topicParts := strings.Split(topic, "/")
+	if len(topicParts) < 5 {
+		subscriptionsUpdatesIgnoredTotal.Inc()
+		return
+	}
 	topicInfoParts := topicParts[4:]
 
 	componentType := topicParts[2]


### PR DESCRIPTION
Fix for panic:

```
Nov 24 20:15:28 ubuntu victron-exporter[13488]: panic: runtime error: slice bounds out of range [4:3]
Nov 24 20:15:28 ubuntu victron-exporter[13488]: goroutine 1445 [running]:
Nov 24 20:15:28 ubuntu victron-exporter[13488]: main.mqttSubscriptionHandler(0x59cc00, 0x4000298000, 0x59b8e0, 0x40003d9590)
Nov 24 20:15:28 ubuntu victron-exporter[13488]:         /home/runner/work/victron-exporter/victron-exporter/mqtt.go:138 +0x34c
Nov 24 20:15:28 ubuntu victron-exporter[13488]: github.com/eclipse/paho%2emqtt%2egolang.(*router).matchAndDispatch.func1.1(0x4f9218, 0x4000298000, 0x59b8e0, 0x40003d9590)
Nov 24 20:15:28 ubuntu victron-exporter[13488]:         /home/runner/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.2.0/router.go:158 +0x4c
Nov 24 20:15:28 ubuntu victron-exporter[13488]: created by github.com/eclipse/paho%2emqtt%2egolang.(*router).matchAndDispatch.func1
Nov 24 20:15:28 ubuntu victron-exporter[13488]:         /home/runner/go/pkg/mod/github.com/eclipse/paho.mqtt.golang@v1.2.0/router.go:157 +0x19c
```