### PR TITLE
Ensure binaries are statically linked

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,8 @@ builds:
   goarm:
     - 6
     - 7
+  env:
+    - CGO_ENABLED=0
   ignore:
     - goos: windows
       goarch: arm


### PR DESCRIPTION
Force C Go off to ensure binaries are statically linked

With the current builds, the Linux binaries are dynamically linked

```shell
file dist/victron-exporter_linux_amd64_v1/victron-exporter
dist/victron-exporter_linux_amd64_v1/victron-exporter: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked, interpreter /lib64/ld-linux-x86-64.so.2, stripped
```

This causes an error when trying to use the x86_64 docker image, as the binary is built on a glibc based system but docker image is musl (see https://stackoverflow.com/questions/66963068/docker-alpine-executable-binary-not-found-even-if-in-path for more info on this):

```shell
docker run ghcr.io/suprememoocow/victron-exporter:v0.5.0
standard_init_linux.go:211: exec user process caused "no such file or directory"
```

After the change the binary outputs are verified to be statically linked, and is able to run on Alpine again is built in Ubuntu for example.

```shell
file dist/victron-exporter_linux_amd64_v1/victron-exporter
dist/victron-exporter_linux_amd64_v1/victron-exporter: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, stripped
```